### PR TITLE
Fix ResolveEndpointV2 error and move email logic to CreateUser

### DIFF
--- a/.aws/aws_ecs_task.json
+++ b/.aws/aws_ecs_task.json
@@ -16,7 +16,8 @@
             "environment": [
                 { "name": "MODE", "value": "production" },
                 { "name": "PORT", "value": ":80" },
-                { "name": "VERSION", "value": "2"}
+                { "name": "VERSION", "value": "2"},
+                { "name": "AWS_REGION", "value": "us-east-1" }
             ],
             "secrets": [
                 { "name": "AWS_BLOCKTABLE_MIN_WRITE_CAPACITY", "valueFrom": "/docter/AWS_BLOCKTABLE_MIN_WRITE_CAPACITY" },

--- a/.aws/aws_ecs_task_staging.json
+++ b/.aws/aws_ecs_task_staging.json
@@ -19,7 +19,8 @@
             "environment": [
                 { "name": "MODE", "value": "staging" },
                 { "name": "VERSION", "value": "2"},
-                { "name": "PORT", "value": ":80" }
+                { "name": "PORT", "value": ":80" },
+                { "name": "AWS_REGION", "value": "us-east-1" }
             ],
             "secrets": [
                 { "name": "AWS_BLOCKTABLE_MIN_WRITE_CAPACITY", "valueFrom": "/docter/AWS_BLOCKTABLE_MIN_WRITE_CAPACITY" },

--- a/daos/users.go
+++ b/daos/users.go
@@ -53,6 +53,29 @@ func (d *DAO) CreateUser(email string) (*models.UserInfo, error) {
 		Admin:      false,
 		Subscriber: false,
 	}
+
+	logger.Info("New account created", "email", email)
+	// Send emails asynchronously to avoid blocking user creation
+	go func() {
+		// Send welcome email to user
+		if err := sendWelcomeEmail(email); err != nil {
+			logger.Error("Failed to send welcome email",
+				"email", email,
+				"error", err)
+		} else {
+			logger.Info("Welcome email sent successfully", "email", email)
+		}
+
+		// Send notification email to support
+		if err := sendNewUserNotificationEmail(email); err != nil {
+			logger.Error("Failed to send new user notification email",
+				"email", email,
+				"error", err)
+		} else {
+			logger.Info("New user notification email sent successfully", "email", email)
+		}
+	}()
+
 	return &user, nil
 }
 
@@ -108,32 +131,6 @@ func (d *DAO) UpsertUser(email string) (*models.UserInfo, error) {
 		}
 	}
 
-	var createdAt string
-	attributevalue.Unmarshal(out.Attributes["created_at"], &createdAt)
-
-	if createdAt == now {
-		logger.Info("New account created", "email", email)
-		// Send emails asynchronously to avoid blocking user creation
-		go func() {
-			// Send welcome email to user
-			if err := sendWelcomeEmail(email); err != nil {
-				logger.Error("Failed to send welcome email",
-					"email", email,
-					"error", err)
-			} else {
-				logger.Info("Welcome email sent successfully", "email", email)
-			}
-
-			// Send notification email to support
-			if err := sendNewUserNotificationEmail(email); err != nil {
-				logger.Error("Failed to send new user notification email",
-					"email", email,
-					"error", err)
-			} else {
-				logger.Info("New user notification email sent successfully", "email", email)
-			}
-		}()
-	}
 	return &user, nil
 }
 


### PR DESCRIPTION
- Add AWS_REGION environment variable to both production and staging ECS task definitions to fix "not found, ResolveEndpointV2" errors
- Move email sending logic from UpsertUser to CreateUser since CreateUser is what's actually called by the auth flow during new user signup
- Email notifications (welcome email to user + notification to support) now properly sent when new accounts are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)